### PR TITLE
Add absent dependencies

### DIFF
--- a/.github/workflows/build_linux_wheel.yml
+++ b/.github/workflows/build_linux_wheel.yml
@@ -47,6 +47,7 @@ jobs:
         python -m pip install cibuildwheel==2.12.3
         pip-compile -o requirements.txt --resolver backtracking --verbose
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        if [ -f requirements_dev.txt ]; then pip install -r requirements_dev.txt; fi
 # Skip linting because we will have a lot of errors since a lot of incorrect type checking for 
 # different reasons, including packages with not type hinting support.
 #     - name: Lint with flake8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,9 @@ dependencies = [
     "sqlcipher3",
     "aiosmtplib",
     "asyncclick",
+    "pathvalidate",
+    "pendulum",
+    "matplotlib_scalebar"
 ]
 dynamic = ["readme"]
 
@@ -51,7 +54,8 @@ dev = [
     "pytest-cov",
     "pytest-openfiles",
     "wheel",
-    "requests-mock"
+    "requests-mock",
+    "pytest-asyncio"
 ]
 
 [tool.setuptools.dynamic]

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,6 @@ click
 sqlcipher3
 aiosmtplib
 asyncclick
+pathvalidate
+pendulum
+matplotlib_scalebar

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,0 +1,9 @@
+pytest
+pytest-astropy
+pytest-arraydiff
+pytest-mock
+pytest-cov
+pytest-openfiles
+wheel
+requests-mock
+pytest-asyncio


### PR DESCRIPTION
Some dependencies were missing in the pyproject.toml and requirements*.txt,  which lead to the test failures.